### PR TITLE
Add Frontier R&D project page

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -11,9 +11,9 @@ export const metadata: Metadata = {
 }
 export const revalidate = 60;
 export default async function ProjectsPage() {
-	const featured = allProjects.find((project) => project.slug === "prodigy")!;
-	const top2 = allProjects.find((project) => project.slug === "scalepoynt")!;
-	const top3 = allProjects.find((project) => project.slug === "denhertog.ca")!;
+	const featured = allProjects.find((project) => project.slug === "frontier-rnd")!;
+	const top2 = allProjects.find((project) => project.slug === "prodigy")!;
+	const top3 = allProjects.find((project) => project.slug === "scalepoynt")!;
 	const sorted = allProjects
 		.filter((p) => p.published)
 		.filter(

--- a/content/projects/frontier-rnd.mdx
+++ b/content/projects/frontier-rnd.mdx
@@ -1,0 +1,22 @@
+---
+title: "Frontier R&D"
+description: Building and maintaining developer tools for Bible translation
+date: "2024-01-01"
+url: https://codexeditor.app
+repository: genesis-ai-dev/codex
+published: true
+---
+
+At Frontier R&D, I build and maintain developer tools that empower Bible translators around the world. My work spans three key projects:
+
+## Codex Editor
+
+I maintain a whitelabeled VSCode build ([genesis-ai-dev/codex](https://github.com/genesis-ai-dev/codex)) used as a platform for custom extensions for translating resources. This involves implementing Windows code signing and various patches to customize the editor into a tailored translation tool.
+
+## Web Codex
+
+I built a scalable Kubernetes platform ([genesis-ai-dev/web-codex](https://github.com/genesis-ai-dev/web-codex)) to host Codex Editor instances online, removing the requirement for local installation. This allows translators to access their workspace from any browser without needing to set up a local development environment.
+
+## Extension Sideloader
+
+I built a custom extension ([andrewhertog/extension-sideloader](https://github.com/andrewhertog/extension-sideloader)) into the Codex binary that automatically installs a specific set of extensions, eliminating the need to bundle them into the binary while providing a natural VSCode-like extension management experience.


### PR DESCRIPTION
## Summary
- Add new portfolio project page for Frontier R&D (`/projects/frontier-rnd`) covering Codex Editor, Web Codex, and Extension Sideloader
- Promote Frontier R&D to the featured project on `/projects`, shifting Prodigy to top 2, Scalepoynt to top 3, and denhertog.ca into the regular grid

## Test plan
- [ ] `npm run dev` → navigate to `/projects` — Frontier R&D appears as the featured project
- [ ] Click through to `/projects/frontier-rnd` — detail page renders with content and GitHub links
- [ ] Remaining projects display correctly in their new positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)