### PR TITLE
feat: add SEO improvements

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,12 +6,16 @@ import { Analytics } from "./components/analytics";
 import { Consent } from "./components/consent"
 
 export const metadata: Metadata = {
+	metadataBase: new URL("https://denhertog.ca"),
 	title: {
 		default: "denhertog.ca",
 		template: "%s | denhertog.ca",
 	},
 	description:
 		"Staff Site Reliability Engineer at Prodigy Education and Scalepoynt",
+	alternates: {
+		canonical: "/",
+	},
 	openGraph: {
 		title: "denhertog.ca",
 		description:
@@ -64,7 +68,21 @@ export default function RootLayout({
 }) {
 	return (
 		<html lang="en" className={[inter.variable, calSans.variable].join(" ")}>
-			<head></head>
+			<head>
+				<script
+					type="application/ld+json"
+					dangerouslySetInnerHTML={{
+						__html: JSON.stringify({
+							"@context": "https://schema.org",
+							"@type": "Person",
+							name: "Andrew den Hertog",
+							url: "https://denhertog.ca",
+							jobTitle: "Staff Site Reliability Engineer",
+							sameAs: ["https://twitter.com/adh88ca"],
+						}),
+					}}
+				/>
+			</head>
 			<body
 				className={`bg-black ${
 					process.env.NODE_ENV === "development" ? "debug-screens" : undefined

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { Mdx } from "@/app/components/mdx";
 import { Header } from "./header";
 import "./mdx.css";
 import { Metadata, ResolvingMetadata } from 'next'
- 
+
 export const revalidate = 60;
 
 type Props = {
@@ -17,10 +17,31 @@ export async function generateMetadata(
   ): Promise<Metadata> {
 
 	const { slug } = await params;
-	return {
-	  title: slug.charAt(0).toUpperCase() + slug.slice(1),
+	const project = allProjects.find((p) => p.slug === slug);
+
+	if (!project) {
+		return { title: slug.charAt(0).toUpperCase() + slug.slice(1) };
 	}
-  }
+
+	return {
+		title: project.title,
+		description: project.description,
+		alternates: {
+			canonical: `/projects/${slug}`,
+		},
+		openGraph: {
+			title: project.title,
+			description: project.description,
+			type: "article",
+			url: `/projects/${slug}`,
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: project.title,
+			description: project.description,
+		},
+	};
+}
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
 	return allProjects
@@ -38,8 +59,25 @@ export default async function PostPage({ params }: Props) {
 		notFound();
 	}
 
+	const jsonLd = {
+		"@context": "https://schema.org",
+		"@type": "Article",
+		headline: project.title,
+		description: project.description,
+		datePublished: project.date,
+		author: {
+			"@type": "Person",
+			name: "Andrew den Hertog",
+			url: "https://denhertog.ca",
+		},
+	};
+
 	return (
 		<div className="bg-zinc-50 min-h-screen">
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+			/>
 			<Header project={project} />
 
 			<article className="px-4 py-12 mx-auto prose prose-zinc prose-quoteless">

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+	return {
+		rules: [
+			{
+				userAgent: "*",
+				allow: "/",
+			},
+		],
+		sitemap: "https://denhertog.ca/sitemap.xml",
+	};
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,42 @@
+import { MetadataRoute } from "next";
+import { allProjects } from ".contentlayer/generated";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+	const staticPages: MetadataRoute.Sitemap = [
+		{
+			url: "https://denhertog.ca",
+			lastModified: new Date(),
+			changeFrequency: "monthly",
+			priority: 1,
+		},
+		{
+			url: "https://denhertog.ca/projects",
+			lastModified: new Date(),
+			changeFrequency: "weekly",
+			priority: 0.9,
+		},
+		{
+			url: "https://denhertog.ca/blog",
+			lastModified: new Date(),
+			changeFrequency: "weekly",
+			priority: 0.8,
+		},
+		{
+			url: "https://denhertog.ca/contact",
+			lastModified: new Date(),
+			changeFrequency: "yearly",
+			priority: 0.5,
+		},
+	];
+
+	const projectPages: MetadataRoute.Sitemap = allProjects
+		.filter((p) => p.published)
+		.map((project) => ({
+			url: `https://denhertog.ca/projects/${project.slug}`,
+			lastModified: project.date ? new Date(project.date) : new Date(),
+			changeFrequency: "monthly" as const,
+			priority: 0.7,
+		}));
+
+	return [...staticPages, ...projectPages];
+}


### PR DESCRIPTION
## Summary
- Add dynamic `sitemap.xml` with static pages and published project pages
- Add dynamic `robots.txt` allowing all crawlers with sitemap reference
- Add JSON-LD structured data (`Person` schema on root layout, `Article` schema on project pages)
- Enhance project page metadata with proper title, description, OG, and Twitter tags
- Add canonical URLs via `metadataBase` and per-page `alternates.canonical`

## Test plan
- [ ] Run `npm run dev` and verify `/sitemap.xml` lists all pages with correct URLs
- [ ] Verify `/robots.txt` shows allow rules and sitemap reference
- [ ] Inspect page source on `/` for `Person` JSON-LD in `<head>`
- [ ] Inspect page source on a project page for `Article` JSON-LD and full OG/Twitter meta tags
- [ ] Validate structured data with [Google Rich Results Test](https://search.google.com/test/rich-results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)