### PR TITLE
fix: reduce ISR revalidation frequency to 1 hour

### DIFF
--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { Header } from "./header";
 import "./mdx.css";
 import { Metadata, ResolvingMetadata } from 'next'
 
-export const revalidate = 60;
+export const revalidate = 3600;
 
 type Props = {
 	params: Promise<{ slug: string }>;

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -9,7 +9,7 @@ import { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Projects',
 }
-export const revalidate = 60;
+export const revalidate = 3600;
 export default async function ProjectsPage() {
 	const featured = allProjects.find((project) => project.slug === "frontier-rnd")!;
 	const top2 = allProjects.find((project) => project.slug === "prodigy")!;


### PR DESCRIPTION
## Summary
- Increases `revalidate` from 60s to 3600s (1 hour) on project pages
- Reduces Netlify serverless function invocations for ISR regeneration

## Test plan
- [ ] Verify project listing page still renders correctly
- [ ] Verify individual project pages still render correctly
- [ ] Confirm reduced function invocations in Netlify dashboard after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)